### PR TITLE
update execution proto, rename state_root to block_hash

### DIFF
--- a/execution-apis/proto/execution/v1/execution.proto
+++ b/execution-apis/proto/execution/v1/execution.proto
@@ -11,13 +11,13 @@ message DoBlockRequest {
 }
 
 message DoBlockResponse {
-  bytes state_root = 1;
+  bytes block_hash = 1;
 }
 
 message InitStateRequest{}
 
 message InitStateResponse {
-  bytes state_root = 1;
+  bytes block_hash = 1;
 }
 
 service ExecutionService {


### PR DESCRIPTION
as title says, what geth was actually using/returning was the block hash not the state root. generally blocks are indexed by block hash also, not state root, so this should be good for reth/other execution engines also